### PR TITLE
Add automatic crate publishing via release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,27 @@
+name: release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -20,6 +20,8 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Run test build
+        run: cargo build --example panic
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:


### PR DESCRIPTION
# Automatic release/publish pipeline.

You'll need to do two things to set it up: one mandatory and one optional.

## Mandatory step:

1. Generate a publish token on crates.io (preferably scoped to `rp2040-panic-usb-boot`, needs only "publish new packages" permission)
![image](https://github.com/user-attachments/assets/2ba8ecfd-3482-4bb0-9807-2906f835c01a)
then
![image](https://github.com/user-attachments/assets/75902ee2-2ed9-4cc7-a210-20878e3a6e38)

2. Paste it into an env var called `CARGO_REGISTRY_TOKEN` in github:

![image](https://github.com/user-attachments/assets/ae2a7de3-66c2-4b29-a190-4a81ef60f8df)

## Optional step:

Do this only if you want more control over the publishing process - this way release-plz will create a branch and ask you to review and merge it before publishing anything (this is helpful if you want to edit release notes beforehand).

Add branch protection on the master branch, forbid direct commits (allow only merge commits).

![image](https://github.com/user-attachments/assets/4ddf218e-be09-4c1a-8d48-bce921ecda35)

![image](https://github.com/user-attachments/assets/3cf67c28-e65f-4201-8652-db51fec5f2bb)

![image](https://github.com/user-attachments/assets/92314633-628d-4761-aa76-db07f0cef9a8)

NB: Set branch protection prior to merging this PR, otherwise release-plz will publish immediately on merge to main.

